### PR TITLE
Etude 1.3 used different values for Big G in text and answers

### DIFF
--- a/appendix_a.html
+++ b/appendix_a.html
@@ -45,7 +45,7 @@ Here are suggested solutions for the études. Of course, your solutions may well
 
   <section data-type="sect1" id="SOLUTION01-ET03">
   <h1>Solution 1-3</h1>
-<pre data-type="programlisting" data-code-language="clojurescript">(def G 6.6784e-11)
+<pre data-type="programlisting" data-code-language="clojurescript">(def G 6.67408e-11)
 
 (defn gravitational-force
   "Calculate gravitational force of two objects of

--- a/ch01-functions-variables.html
+++ b/ch01-functions-variables.html
@@ -63,12 +63,12 @@ formulas.core=> (centripetal 30 2)</pre>
   
   <p>
   <math id="p7.m1" class="ltx_Math" alttext="F={Gm_{1}m_{2}\over r^{2}}" display="inline"><mrow><mi>F</mi><mo>=</mo><mfrac><mrow><mi>G</mi><mo>⁢</mo><msub><mi>m</mi><mn>1</mn></msub><mo>⁢</mo><msub><mi>m</mi><mn>2</mn></msub></mrow><msup><mi>r</mi><mn>2</mn></msup></mfrac></mrow></math>,
-  where the gravitational constant <math  class="ltx_Math" alttext="G=6.67384\times 10^{-11}" display="inline"><mrow><mi>G</mi><mo>=</mo><mrow><mn>6.67384</mn><mo>×</mo><msup><mn>10</mn><mrow><mo>-</mo><mn>11</mn></mrow></msup></mrow></mrow></math>. Use a <code>def</code> for the gravitational constant.</p>
+  where the gravitational constant <math  class="ltx_Math" alttext="G=6.67408\times 10^{-11}" display="inline"><mrow><mi>G</mi><mo>=</mo><mrow><mn>6.67408</mn><mo>×</mo><msup><mn>10</mn><mrow><mo>-</mo><mn>11</mn></mrow></msup></mrow></mrow></math>. Use a <code>def</code> for the gravitational constant.</p>
   
   <p>Here is the calculation for two masses of 100kg that are 5 meters apart:</p>
   
   <pre>formulas.core=> (gravitational-force 100 100 5)
-2.67136e-8</pre>
+2.6696320000000002e-8</pre>
 
   <p>See a suggested solution: <a href="#SOLUTION01-ET03" data-type="xref">#SOLUTION01-ET03</a></p>
   </section>

--- a/code/chapter01/formulas/src/formulas/core.cljs
+++ b/code/chapter01/formulas/src/formulas/core.cljs
@@ -32,7 +32,7 @@
   [a b]
   (- (* 2 (+ (* a a) (* b b))) (* (+ a b) (+ a b))))
 
-(def G 6.6784e-11)
+(def G 6.67408e-11)
 
 (defn gravitational-force
   "Calculate gravitational force of two objects of


### PR DESCRIPTION
Updated chapter 1 to use standard wikipedia value for gravitational constant, made displayed expected answer match actual code output, and updated solution in appendix a to use same value also.
